### PR TITLE
Update readme (to fix typescript usage)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ To use:
 
 ```ts
 // Note `* as` and `new Stripe` for TypeScript:
-import * as Stripe from 'stripe';
+import Stripe from 'stripe';
 const stripe = new Stripe('sk_test_...');
 
 const customer: Promise<Stripe.customers.ICustomer> = stripe.customers.create(/* ... */);


### PR DESCRIPTION
## ENV

```
$ node -v
v10.5.0

$ npm -v
6.1.0

$ cat package.json  | jq .devDependencies
{
  "stripe": "^6.25.1",
  "@types/stripe": "^6.19.7",
  "typescript": "^3.3.3"
}

$ cat tsconfig.json
{
  "compilerOptions": {
    "target": "es6",
    "module": "commonjs",
    "outDir": "./dist",
    "strict": true,
    "esModuleInterop": true
  },
  "include": [
    "libs"
  ]
}

```

## Expected

I want to write code by TypeScript and the README.md told me by the following code.

```
import * as Stripe from 'stripe';
const stripe = new Stripe('sk_test_...');

const customer: Promise<Stripe.customers.ICustomer> = stripe.customers.create(/* ... */);
```

## Actual
When I try to build the code, I got the following error.

```
$ tsc
> tsc

libs/index.ts:4:16 - error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.

4 const stripe = new Stripe(sk)
                 ~~~~~~~~~~~~~~

  libs/shiftet.ts:1:1
    1 import * as Stripe from 'stripe';
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    Type originates at this import. A namespace-style import cannot be called or constructed, and will cause a failure at runtime. Consider using a default import or import require here instead.

```

## Issue
I think the example should be the following code.

```
import Stripe from 'stripe';
const stripe = new Stripe('sk_test_...');

const customer: Promise<Stripe.customers.ICustomer> = stripe.customers.create(/* ... */);
```